### PR TITLE
Refactor CSS in "Main Features"

### DIFF
--- a/client/src/domain/MainFeatures/MainFeatures.js
+++ b/client/src/domain/MainFeatures/MainFeatures.js
@@ -34,10 +34,8 @@ export default function MainFeatures() {
 
     return (
         <div className={MFCSS.container}>
-            <div className={MFCSS.description}>
-                <p className={MFCSS.header}>WHO WE ARE</p>
-                <p className={MFCSS.intro}>Codercademy is a [main description here: brief yet impactful]</p>
-            </div>
+            <h1>WHO WE ARE</h1>
+            <p>Codercademy is a [main description here: brief yet impactful]</p>
 
             <p className={MFCSS.activities}>WHAT WE DO</p>
             <div className={MFCSS.wrapper}>

--- a/client/src/domain/MainFeatures/MainFeatures.js
+++ b/client/src/domain/MainFeatures/MainFeatures.js
@@ -40,7 +40,7 @@ export default function MainFeatures() {
             </section>
 
             <section>
-                <h1 className={MFCSS.activities}>WHAT WE DO</h1>
+                <h1>WHAT WE DO</h1>
                 <div className={MFCSS.wrapper}>
                     {features}
                 </div>

--- a/client/src/domain/MainFeatures/MainFeatures.js
+++ b/client/src/domain/MainFeatures/MainFeatures.js
@@ -17,9 +17,9 @@ const featuresData = [{
 function FeaturesItem({ title, desc }) {
     return (
         <div className={MFCSS.feature_container}>
-            <p className={MFCSS.item_header}>{title}</p>
+            <h1>{title}</h1>
             <div className={MFCSS.icon}></div>
-            <p className={MFCSS.item_intro}>{desc}</p>
+            <p>{desc}</p>
         </div>
     )
 }

--- a/client/src/domain/MainFeatures/MainFeatures.js
+++ b/client/src/domain/MainFeatures/MainFeatures.js
@@ -41,7 +41,7 @@ export default function MainFeatures() {
 
             <section>
                 <h1>WHAT WE DO</h1>
-                <div className={MFCSS.wrapper}>
+                <div className={MFCSS.features}>
                     {features}
                 </div>
             </section>

--- a/client/src/domain/MainFeatures/MainFeatures.js
+++ b/client/src/domain/MainFeatures/MainFeatures.js
@@ -34,13 +34,17 @@ export default function MainFeatures() {
 
     return (
         <div className={MFCSS.container}>
-            <h1>WHO WE ARE</h1>
-            <p>Codercademy is a [main description here: brief yet impactful]</p>
+            <section>
+                <h1>WHO WE ARE</h1>
+                <p>Codercademy is a [main description here: brief yet impactful]</p>
+            </section>
 
-            <p className={MFCSS.activities}>WHAT WE DO</p>
-            <div className={MFCSS.wrapper}>
-                {features}
-            </div>
+            <section>
+                <h1 className={MFCSS.activities}>WHAT WE DO</h1>
+                <div className={MFCSS.wrapper}>
+                    {features}
+                </div>
+            </section>
         </div>
     )
 }

--- a/client/src/domain/MainFeatures/MainFeatures.js
+++ b/client/src/domain/MainFeatures/MainFeatures.js
@@ -17,11 +17,9 @@ const featuresData = [{
 function FeaturesItem({ title, desc }) {
     return (
         <div className={MFCSS.feature_container}>
-            <div className={MFCSS.item}>
-                <p className={MFCSS.item_header}>{title}</p>
-                <div className={MFCSS.icon}></div>
-                <p className={MFCSS.item_intro}>{desc}</p>
-            </div>
+            <p className={MFCSS.item_header}>{title}</p>
+            <div className={MFCSS.icon}></div>
+            <p className={MFCSS.item_intro}>{desc}</p>
         </div>
     )
 }

--- a/client/src/domain/MainFeatures/MainFeatures.module.css
+++ b/client/src/domain/MainFeatures/MainFeatures.module.css
@@ -23,7 +23,7 @@
   line-height: 28px;
 }
 
-.wrapper {
+.features {
   display: flex;
   gap: 56px;
   flex-wrap: wrap;

--- a/client/src/domain/MainFeatures/MainFeatures.module.css
+++ b/client/src/domain/MainFeatures/MainFeatures.module.css
@@ -35,10 +35,10 @@
 }
 
 .wrapper {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, 372px);
+  display: flex;
+  gap: 56px;
+  flex-wrap: wrap;
   justify-content: center;
-  grid-gap: 56px;
 }
 
 .feature_container {

--- a/client/src/domain/MainFeatures/MainFeatures.module.css
+++ b/client/src/domain/MainFeatures/MainFeatures.module.css
@@ -1,3 +1,4 @@
+/* Global container  */
 .container {
   background-color: var(--white-medium);
   padding-top: 72px;
@@ -5,7 +6,7 @@
   text-align: center;
   display: flex;
   flex-direction: column;
-  gap: 100px;
+  gap: 100px; /*gap between each section in the container */
 }
 
 .container h1 {
@@ -23,6 +24,7 @@
   line-height: 28px;
 }
 
+/* container for the "features" subsection */
 .features {
   display: flex;
   gap: 56px;
@@ -30,6 +32,7 @@
   justify-content: center;
 }
 
+/* container for individual features */
 .feature_container {
   border: 4px solid rgba(228, 110, 0, 0.75);
   border-radius: 30px;
@@ -53,7 +56,7 @@
   color: var(--gray-medium);
 }
 
-.icon {
+.feature_container > .icon {
   border: 3px dashed var(--border-yellow);
   border-radius: 50%;
   width: 196px;

--- a/client/src/domain/MainFeatures/MainFeatures.module.css
+++ b/client/src/domain/MainFeatures/MainFeatures.module.css
@@ -50,14 +50,18 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  padding: 20px;
 }
 
-.item_header {
+.feature_container > h1 {
   color: var(--gray-medium);
-  font-size: 30px;
   font-weight: 500;
-  line-height: 35.55px;
+}
+
+.feature_container > p {
+  font-size: 1.2em;
   text-align: center;
+  color: var(--gray-medium);
 }
 
 .icon {
@@ -67,12 +71,4 @@
   height: 196px;
   margin-top: 33px;
   margin-bottom: 33px;
-}
-
-.item_intro {
-  font-weight: 500;
-  font-size: 20px;
-  line-height: 24px;
-  text-align: center;
-  color: var(--gray-medium);
 }

--- a/client/src/domain/MainFeatures/MainFeatures.module.css
+++ b/client/src/domain/MainFeatures/MainFeatures.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  color: #ff7a00;
+  color: var(--yellow-bold);
   font-size: 30px;
   font-weight: 600;
   line-height: 36px;

--- a/client/src/domain/MainFeatures/MainFeatures.module.css
+++ b/client/src/domain/MainFeatures/MainFeatures.module.css
@@ -2,21 +2,18 @@
   background-color: var(--white-medium);
   padding-top: 72px;
   padding-bottom: 199px;
-}
-
-.description {
   text-align: center;
 }
 
-.header {
+.container h1 {
   color: var(--yellow-bold);
   font-size: 30px;
   font-weight: 600;
   line-height: 36px;
+  margin-bottom: 29px;
 }
 
-.intro {
-  margin-top: 29px;
+.container p {
   color: var(--gray-regular);
   font-size: 24px;
   font-weight: 400;

--- a/client/src/domain/MainFeatures/MainFeatures.module.css
+++ b/client/src/domain/MainFeatures/MainFeatures.module.css
@@ -3,6 +3,9 @@
   padding-top: 72px;
   padding-bottom: 199px;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 100px;
 }
 
 .container h1 {
@@ -18,17 +21,6 @@
   font-size: 24px;
   font-weight: 400;
   line-height: 28px;
-}
-
-.activities {
-  margin-top: 133px;
-  color: var(--yellow-bold);
-  font-size: 30px;
-  font-weight: 600;
-  line-height: 36px;
-  text-align: center;
-  margin-bottom: 42px;
-  text-align: center;
 }
 
 .wrapper {

--- a/client/src/domain/MainFeatures/MainFeatures.module.css
+++ b/client/src/domain/MainFeatures/MainFeatures.module.css
@@ -47,17 +47,9 @@
   width: 372px;
   height: 519px;
   display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.item {
-  width: 282px;
-  height: 447px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 .item_header {


### PR DESCRIPTION
The current styling contains multiple classes with redundant nesting, often making it difficult to introduce new changes when editing CSS.  

``` <div className={MFCSS.container}>
    <div className={MFCSS.description}>
        <p className={MFCSS.header}>WHO WE ARE</p>
        <p className={MFCSS.intro}>Codercademy is a [main description here: brief yet impactful]</p>
    </div>

    <p className={MFCSS.activities}>WHAT WE DO</p>
    <div className={MFCSS.wrapper}>
        {features}
    </div>
</div>
```



This PR reduces the amount of clutter in the JSX making it easier to introduce new changes, as well as a more hierarchical CSS structure that cascades changes instead of re-styling redundant code. This also minimizes the need for classnames in the JSX, allowing for simple semantic tags like \<h1\> and \<p\> since it's not like we're constantly changing the style of those.

```<div className={MFCSS.container}>
    <section>
        <h1>WHO WE ARE</h1>
        <p>Codercademy is a [main description here: brief yet impactful]</p>
    </section>

    <section>
        <h1>WHAT WE DO</h1>
        <div className={MFCSS.features}>
            {features}
        </div>
    </section>
</div>
```

No visual changes are introduced, besides fixing the alignment of the features in specific viewports. Big changes to the CSS pero still the same output, watchu think? I plan on going through the other components sad 

Before 
![image](https://user-images.githubusercontent.com/54239564/159006439-4207e7f1-505a-4d32-914f-e7ffc817da33.png)
![image](https://user-images.githubusercontent.com/54239564/159006485-2aea6ef8-81e3-4dbb-99bb-67dbf1db52b2.png)


After
![image](https://user-images.githubusercontent.com/54239564/159006393-3527e961-dcf6-4a01-b11b-442d4a50a783.png)
![image](https://user-images.githubusercontent.com/54239564/159006542-921818c9-5899-4ac6-a54c-7dacf4c526fc.png)
